### PR TITLE
Close tooltip when button clicked

### DIFF
--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -186,6 +186,7 @@ export default {
             }
         },
         onClick() {
+            this.close()
             if (this.triggers.indexOf('click') < 0) return
             // if not active, toggle after clickOutside event
             // this fixes toggling programmatic


### PR DESCRIPTION
If a click on the object the tooltip is encapsulating switches to a different screen, the tooltip can remain open. (and won't close until you return to the object, hover over it and hover-off) When the tooltip detects a click, if the tooltip is already open and the click is about to cause a switch away circumventing the default hover / blur close, then enforce a close first.

No issue logged for this, happy to see this scrapped if there's a better way but it seems like an easy one-liner.

## Proposed Changes
Just one; force a tooltip close in the tooltip onclick event.
Reason; if your tooltip encompasses a button which causes a cached VueRouter switch to another pane, the blur event doesn't get called and the tooltop can stay on the screen. Click always needs to close the tooltip if it's open.

Example that exhibits the issue;

```html
<b-tooltip 
    label='Show emails from the current service provider'
    position="is-top" type="is-dark" class="square-tooltip"
    v-if="allowEmails" append-to-body>
        <a class="square-button is-info" type="button" @click="onClickEmails">                    
            <div class="square-icon"><b-icon icon="email-search-outline" size="is-medium"></b-icon></div>
            <div class="square-text">Emails</div>
        </a>
<b-tooltip>
